### PR TITLE
fix framework ready hook for web startup

### DIFF
--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -1,25 +1,11 @@
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
-const { getDefaultConfig } = require('expo/metro-config');
 
 declare global {
   interface Window {
     frameworkReady?: () => void;
   }
 }
-
-const config = getDefaultConfig(__dirname);
-
-// Add web support
-config.resolver.platforms = ['ios', 'android', 'web'];
-
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-    plugins: [],
-  };
-};
 
 export function useFrameworkReady() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove metro and babel configs from `useFrameworkReady` hook to prevent runtime bundling error

## Testing
- `npm run lint` (fails: TypeError: fetch failed)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68927338178c83239c32f70f0ba79506