### PR TITLE
configure babel to handle commonjs helpers correctly

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,11 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    // Allow Babel to automatically determine whether a file is an ES module
+    // or CommonJS. This prevents CommonJS helpers in node_modules from being
+    // transformed into ESM default exports, which can cause runtime errors
+    // such as "_interopRequireDefault is not a function" on web.
+    sourceType: 'unambiguous',
     plugins: [],
   };
 };

--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -1,25 +1,11 @@
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
-const { getDefaultConfig } = require('expo/metro-config');
 
 declare global {
   interface Window {
     frameworkReady?: () => void;
   }
 }
-
-const config = getDefaultConfig(__dirname);
-
-// Add web support
-config.resolver.platforms = ['ios', 'android', 'web'];
-
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-    plugins: [],
-  };
-};
 
 export function useFrameworkReady() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- set Babel `sourceType` to `unambiguous` so CommonJS helpers like `@babel/runtime/helpers/interopRequireDefault` remain callable functions and avoid `_interopRequireDefault is not a function` errors on web

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68927338178c83239c32f70f0ba79506