### PR TITLE
configure babel runtime helpers to avoid _interopRequireDefault errors

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,13 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: [],
+    // Allow Babel to automatically determine whether a file is an ES module
+    // or CommonJS. This prevents CommonJS helpers in node_modules from being
+    // transformed into ESM default exports, which can cause runtime errors
+    // such as "_interopRequireDefault is not a function" on web.
+    sourceType: 'unambiguous',
+    // Ensure runtime helpers are loaded using CommonJS to avoid interop issues
+    // when Metro bundles @babel/runtime for the web platform.
+    plugins: [['@babel/plugin-transform-runtime', { useESModules: false }]],
   };
 };

--- a/hooks/useFrameworkReady.ts
+++ b/hooks/useFrameworkReady.ts
@@ -1,25 +1,11 @@
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
-const { getDefaultConfig } = require('expo/metro-config');
 
 declare global {
   interface Window {
     frameworkReady?: () => void;
   }
 }
-
-const config = getDefaultConfig(__dirname);
-
-// Add web support
-config.resolver.platforms = ['ios', 'android', 'web'];
-
-module.exports = function (api) {
-  api.cache(true);
-  return {
-    presets: ['babel-preset-expo'],
-    plugins: [],
-  };
-};
 
 export function useFrameworkReady() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure Babel runtime helpers are imported via CommonJS to keep `_interopRequireDefault` callable

## Testing
- `npm run lint` *(fails: TypeError: fetch failed)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68927338178c83239c32f70f0ba79506